### PR TITLE
Update strip-ansi from ^3.0.0 to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "is-fullwidth-code-point": "^2.0.0",
-    "strip-ansi": "^3.0.0"
+    "strip-ansi": "^4.0.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
Includes a breaking change https://github.com/chalk/strip-ansi/commit/097894423fedb6b4dca3005ad45608b893fcdcf8 but doesn't affect strip-ansi, which has already dropped support for Node.js < 4.