### PR TITLE
feat: initial ZWJ handling (disabled by default)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,11 @@ stringWidth('a');
 - [string-length](https://github.com/sindresorhus/string-length) - Get the real length of a string
 - [widest-line](https://github.com/sindresorhus/widest-line) - Get the visual width of the widest line in a string
 
+## Contributing
+Recommended reads:
+- https://en.wikipedia.org/wiki/Code_point
+- https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms
+- https://en.wikipedia.org/wiki/Zero-width_non-joiner
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -24,3 +24,11 @@ test('ignores control characters', t => {
 test('handles combining characters', t => {
 	t.is(m('x\u0300'), 1);
 });
+
+test('handles zero-width-joiners - ZWJ ONLY', t => {
+	// Random samples from http://unicode.org/emoji/charts/emoji-zwj-sequences.html
+	// Family: man, woman, boy
+	t.is(m('\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}', {joinAroundZWJ: true}), 1);
+	// Family: woman, woman, boy, boy
+	t.is(m('👩‍👩‍👦‍👦', {joinAroundZWJ: true}), 1);
+});


### PR DESCRIPTION
This is an early attempt to fix https://github.com/sindresorhus/string-width/issues/2

This PR only handles ZWJ, and it's disabled by default.

I'll handle ZWNJ, variants and skin tones in other PRs if this one is accepted.