### PR TITLE
feat: add option to disable `stripAnsi`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,18 @@
 const stripAnsi = require('strip-ansi');
 const isFullwidthCodePoint = require('is-fullwidth-code-point');
 
-module.exports = str => {
+module.exports = (str, opts) => {
 	if (typeof str !== 'string' || str.length === 0) {
 		return 0;
 	}
 
-	str = stripAnsi(str);
+	opts = Object.assign({
+		stripAnsi: true
+	}, opts);
+
+	if (opts.stripAnsi) {
+		str = stripAnsi(str);
+	}
 
 	let width = 0;
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,25 @@ stringWidth('a');
 //=> 1
 ```
 
+## API
+
+### stringWidth(str, [options])
+
+#### str
+
+Type: `string`
+
+String to count visual width.
+
+#### options
+
+##### stripAnsi
+
+Type: `boolean`<br>
+Default: `true`
+
+Determine whether to strip ansi.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -24,3 +24,7 @@ test('ignores control characters', t => {
 test('handles combining characters', t => {
 	t.is(m('x\u0300'), 1);
 });
+
+test('option to disable stripAnsi', t => {
+	t.not(m('\u001B[31m\u001B[39m', {stripAnsi: false}), 0);
+});


### PR DESCRIPTION
Use for [prettier](https://github.com/prettier/prettier), need this option since there may be ansi strings in the source code.