### PR TITLE
Update to strip-ansi v6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"dependencies": {
 		"emoji-regex": "^8.0.0",
 		"is-fullwidth-code-point": "^3.0.0",
-		"strip-ansi": "^5.2.0"
+		"strip-ansi": "^6.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",


### PR DESCRIPTION
strip-ansi@6 is only semver major because it dropped support for node.js 6, not a breaking change here.

This is part of an effort to make the next version of `yargs` use a single copy of `strip-ansi` (other PR at chalk/wrap-ansi#41).