### PR TITLE
Improve performance by performing an early exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ const isFullwidthCodePoint = require('is-fullwidth-code-point');
 const emojiRegex = require('emoji-regex');
 
 const stringWidth = string => {
+	if (typeof string !== 'string' || string.length === 0) {
+		return 0;
+	}
+
 	string = string.replace(emojiRegex(), '  ');
 
-	if (typeof string !== 'string' || string.length === 0) {
+	if (string.length === 0) {
 		return 0;
 	}
 


### PR DESCRIPTION
This improves performance by not performing `string.replace()` using the Emoji regular expression when the input is an empty string.

Also, when the input is not a string, the check should be performed before `string.replace()`.