### PR TITLE
Improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,14 @@ const stringWidth = string => {
 	if (typeof string !== 'string' || string.length === 0) {
 		return 0;
 	}
-
-	string = string.replace(emojiRegex(), '  ');
+	
+	string = stripAnsi(string);
 
 	if (string.length === 0) {
 		return 0;
 	}
 
-	string = stripAnsi(string);
+	string = string.replace(emojiRegex(), '  ');
 
 	let width = 0;
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const stringWidth = string => {
 	if (typeof string !== 'string' || string.length === 0) {
 		return 0;
 	}
-	
+
 	string = stripAnsi(string);
 
 	if (string.length === 0) {


### PR DESCRIPTION
The old one check `.length` after replacing emoji, but empty string already returned, replace emoji can't get an empty string on non-empty string, so the length check is actually dead code.

But `stripAnsi` may return empty string.