### PR TITLE
Add `ambiguousIsNarrow` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,4 +17,8 @@ stringWidth('\u001B[1m古\u001B[22m');
 //=> 2
 ```
 */
-export default function stringWidth(string: string): number;
+export interface Options {
+	ambiguousIsNarrow: boolean;
+}
+
+export default function stringWidth(string: string, options?: Options): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,12 @@
+export interface Options {
+	/**
+	Count [Ambiguous characters](https://www.unicode.org/reports/tr11/#Ambiguous) as a width of 1, false counts as 2.
+
+	@default false
+	*/
+	readonly ambiguousIsNarrow: boolean;
+}
+
 /**
 Get the visual width of a string - the number of columns required to display it.
 
@@ -17,8 +26,4 @@ stringWidth('\u001B[1m古\u001B[22m');
 //=> 2
 ```
 */
-export interface Options {
-	ambiguousIsNarrow: boolean;
-}
-
 export default function stringWidth(string: string, options?: Options): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export interface Options {
 	/**
-	Count [Ambiguous characters](https://www.unicode.org/reports/tr11/#Ambiguous) as a width of 1, false counts as 2.
+	Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide (count of 2).
 
 	@default false
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export interface Options {
 	/**
-	Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide (count of 2).
+	Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide width (count of 2).
 
 	@default false
 	*/

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 import stripAnsi from 'strip-ansi';
-import isFullwidthCodePoint from 'is-fullwidth-code-point';
+import eaw from 'eastasianwidth';
 import emojiRegex from 'emoji-regex';
 
-export default function stringWidth(string) {
+export default function stringWidth(string, options = {}) {
 	if (typeof string !== 'string' || string.length === 0) {
 		return 0;
 	}
@@ -30,12 +30,18 @@ export default function stringWidth(string) {
 			continue;
 		}
 
-		// Surrogates
-		if (codePoint > 0xFFFF) {
-			index++;
+		const code = eaw.eastAsianWidth(string.charAt(index));
+		switch (code) {
+			case 'F':
+			case 'W':
+				width += 2;
+				break;
+			case 'A':
+				width += options.ambiguousIsNarrow ? 1 : 2;
+				break;
+			default:
+				width += 1;
 		}
-
-		width += isFullwidthCodePoint(codePoint) ? 2 : 1;
 	}
 
 	return width;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export default function stringWidth(string, options = {}) {
 
 	string = string.replace(emojiRegex(), '  ');
 
+	const ambiguousCharWidth = options.ambiguousIsNarrow ? 1 : 2;
 	let width = 0;
 
 	for (let index = 0; index < string.length; index++) {
@@ -37,7 +38,7 @@ export default function stringWidth(string, options = {}) {
 				width += 2;
 				break;
 			case 'A':
-				width += options.ambiguousIsNarrow ? 1 : 2;
+				width += ambiguousCharWidth;
 				break;
 			default:
 				width += 1;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import stripAnsi from 'strip-ansi';
-import eaw from 'eastasianwidth';
+import eastAsianWidth from 'eastasianwidth';
 import emojiRegex from 'emoji-regex';
 
 export default function stringWidth(string, options = {}) {
@@ -30,7 +30,7 @@ export default function stringWidth(string, options = {}) {
 			continue;
 		}
 
-		const code = eaw.eastAsianWidth(string.charAt(index));
+		const code = eastAsianWidth.eastAsianWidth(string.charAt(index));
 		switch (code) {
 			case 'F':
 			case 'W':

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,3 +2,5 @@ import {expectType} from 'tsd';
 import stringWidth from './index.js';
 
 expectType<number>(stringWidth('古'));
+
+expectType<number>(stringWidth('★', {ambiguousIsNarrow: true}));

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
 		"fixed-width"
 	],
 	"dependencies": {
+		"eastasianwidth": "^0.2.0",
 		"emoji-regex": "^9.2.2",
-		"is-fullwidth-code-point": "^4.0.0",
 		"strip-ansi": "^7.0.1"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Type: `object`
 Type: `boolean`\
 Default: `false`
 
-Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide (count of 2).
+Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide width (count of 2).
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,27 @@ stringWidth('\u001B[1m古\u001B[22m');
 //=> 2
 ```
 
+## API
+
+### stringWidth(string, options?)
+
+#### string
+
+Type: `string`
+
+The string to be counted.
+
+#### options
+
+Type: `object`
+
+##### ambiguousIsNarrow
+
+Type: `boolean`\
+Default: `false`
+
+Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide (count of 2).
+
 ## Related
 
 - [string-width-cli](https://github.com/sindresorhus/string-width-cli) - CLI for this module

--- a/test.js
+++ b/test.js
@@ -5,6 +5,8 @@ test('main', t => {
 	t.is(stringWidth('abcde'), 5);
 	t.is(stringWidth('古池や'), 6);
 	t.is(stringWidth('あいうabc'), 9);
+	t.is(stringWidth('あいう★'), 8);
+	t.is(stringWidth('あいう★', {ambiguousIsNarrow: true}), 7);
 	t.is(stringWidth('ノード.js'), 9);
 	t.is(stringWidth('你好'), 4);
 	t.is(stringWidth('안녕하세요'), 10);


### PR DESCRIPTION
Resolves #1 

I switched to [this](https://github.com/komagata/eastasianwidth) library which can resolve ambiguous characters.
In [East Asian legacy character encodings](http://www.unicode.org/reports/tr11/#Recommendations) (e.g. Japanese environment), ambiguous characters are resolved as full-width by default. We can set the option to make them half-width characters.