### PR TITLE
Add `countAnsiEscapeCodes` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface Options {
 	readonly ambiguousIsNarrow: boolean;
 
 	/**
-	Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted. They are ignored by default.
+	Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted.
 
 	@default false
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,13 @@ export interface Options {
 	@default true
 	*/
 	readonly ambiguousIsNarrow: boolean;
+
+	/**
+	Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted. They are ignored by default.
+
+	@default false
+	*/
+	readonly countAnsiEscapeCodes: boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,14 +4,14 @@ export type Options = {
 
 	@default true
 	*/
-	readonly ambiguousIsNarrow: boolean;
+	readonly ambiguousIsNarrow?: boolean;
 
 	/**
 	Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted.
 
 	@default false
 	*/
-	readonly countAnsiEscapeCodes: boolean;
+	readonly countAnsiEscapeCodes?: boolean;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -9,10 +9,13 @@ export default function stringWidth(string, options = {}) {
 
 	options = {
 		ambiguousIsNarrow: true,
+		countAnsiEscapeCodes: false,
 		...options
 	};
 
-	string = stripAnsi(string);
+	if (!options.countAnsiEscapeCodes) {
+		string = stripAnsi(string);
+	}
 
 	if (string.length === 0) {
 		return 0;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,5 +2,5 @@ import {expectType} from 'tsd';
 import stringWidth from './index.js';
 
 expectType<number>(stringWidth('古'));
-
-expectType<number>(stringWidth('★', {ambiguousIsNarrow: true}));
+expectType<number>(stringWidth('★', {ambiguousIsNarrow: false}));
+expectType<number>(stringWidth('\u001B[31m\u001B[39m', {countAnsiEscapeCodes: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,5 +2,6 @@ import {expectType} from 'tsd';
 import stringWidth from './index.js';
 
 expectType<number>(stringWidth('古'));
+expectType<number>(stringWidth('★', {}));
 expectType<number>(stringWidth('★', {ambiguousIsNarrow: false}));
 expectType<number>(stringWidth('\u001B[31m\u001B[39m', {countAnsiEscapeCodes: true}));

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguo
 Type: `boolean`\
 Default: `false`
 
-Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted. They are ignored by default.
+Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,16 @@ Type: `object`
 ##### ambiguousIsNarrow
 
 Type: `boolean`\
-Default: `false`
+Default: `true`
 
 Count [ambiguous width characters](https://www.unicode.org/reports/tr11/#Ambiguous) as having narrow width (count of 1) instead of wide width (count of 2).
+
+##### countAnsiEscapeCodes
+
+Type: `boolean`\
+Default: `false`
+
+Whether [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) should be counted. They are ignored by default.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ test('main', t => {
 	t.is(stringWidth('안녕하세요'), 10);
 	t.is(stringWidth('A\uD83C\uDE00BC'), 5, 'surrogate');
 	t.is(stringWidth('\u001B[31m\u001B[39m'), 0);
+	t.is(stringWidth('\u001B[31m\u001B[39m', {countAnsiEscapeCodes: true}), 8);
 	t.is(stringWidth('\u001B]8;;https://github.com\u0007Click\u001B]8;;\u0007'), 5);
 	t.is(stringWidth('\u{231A}'), 2, '⌚ default emoji presentation character (Emoji_Presentation)');
 	t.is(stringWidth('\u{2194}\u{FE0F}'), 2, '↔️ default text presentation character rendered as emoji');


### PR DESCRIPTION
Same as https://github.com/sindresorhus/string-length/pull/16, add an option to count ANSI escape codes.
Previously requested by https://github.com/sindresorhus/string-width/pull/15, and Prettier do need count them.