### PR TITLE
Handle grapheme contains more than one code points

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,12 @@ export default function stringWidth(string, options = {}) {
 			continue;
 		}
 
+		// For grapheme contains more than one code points
+		if (character.codePointAt(1)) {
+			width += 2;
+			continue;
+		}
+
 		width += eastAsianWidth(codePoint, {ambiguousAsWide: !ambiguousIsNarrow});
 	}
 


### PR DESCRIPTION
I'm not sure if there are cases calculated wrong, but the grapheme width should not decided by the first code point.