### PR TITLE
perf: cache intl object

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ import stripAnsi from 'strip-ansi';
 import {eastAsianWidth} from 'get-east-asian-width';
 import emojiRegex from 'emoji-regex';
 
+const segmenter = new Intl.Segmenter();
+
 export default function stringWidth(string, options = {}) {
 	if (typeof string !== 'string' || string.length === 0) {
 		return 0;
@@ -21,8 +23,9 @@ export default function stringWidth(string, options = {}) {
 	}
 
 	let width = 0;
+	const eastAsianWidthOptions = {ambiguousAsWide: !ambiguousIsNarrow};
 
-	for (const {segment: character} of new Intl.Segmenter().segment(string)) {
+	for (const {segment: character} of segmenter.segment(string)) {
 		const codePoint = character.codePointAt(0);
 
 		// Ignore control characters
@@ -40,7 +43,7 @@ export default function stringWidth(string, options = {}) {
 			continue;
 		}
 
-		width += eastAsianWidth(codePoint, {ambiguousAsWide: !ambiguousIsNarrow});
+		width += eastAsianWidth(codePoint, eastAsianWidthOptions);
 	}
 
 	return width;


### PR DESCRIPTION
Inspired by https://twitter.com/jarredsumner/status/1749032292771942605

Before:

```
cpu: AMD Ryzen 9 5950X 16-Core Processor
runtime: node v20.7.0 (x64-linux)

benchmark                                    time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------------------- -----------------------------
npm/string-width (ansi + emoji + ascii)   13.78 µs/iter     (11.2 µs … 1.24 ms)  11.74 µs  26.01 µs  28.73 µs
npm/string-width (ansi + emoji)            8.43 µs/iter      (8.09 µs … 9.2 µs)   8.65 µs    9.2 µs    9.2 µs
npm/string-width (ansi + ascii)           11.07 µs/iter     (9.27 µs … 3.05 ms)   9.87 µs  12.07 µs   13.8 µs
```

Now:

```
cpu: AMD Ryzen 9 5950X 16-Core Processor
runtime: node v20.7.0 (x64-linux)

benchmark                                    time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------------------------- -----------------------------
npm/string-width (ansi + emoji + ascii)    8.07 µs/iter   (7.08 µs … 397.88 µs)    7.4 µs   9.09 µs  11.83 µs
npm/string-width (ansi + emoji)            2.94 µs/iter     (2.82 µs … 3.34 µs)   2.99 µs   3.34 µs   3.34 µs
npm/string-width (ansi + ascii)            6.23 µs/iter     (6.18 µs … 6.32 µs)   6.24 µs   6.32 µs   6.32 µs
```

Benchmark:

```js
import {bench, run} from 'mitata';
import npmStringWidth from './index.js';

bench('npm/string-width (ansi + emoji + ascii)', () => {
	npmStringWidth('hello there! 😀\u001B[31m😀😀');
});

bench('npm/string-width (ansi + emoji)', () => {
	npmStringWidth('😀\u001B[31m😀😀');
});

bench('npm/string-width (ansi + ascii)', () => {
	npmStringWidth('\u001B[31mhello there!');
});

run();
```