### PR TITLE
Zero-width character handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ export default function stringWidth(string, options = {}) {
 			continue;
 		}
 
+		// Ignore zero-width characters
+		if (codePoint === 0x200B) {
+			continue;
+		}
+
 		// Ignore combining characters
 		if (codePoint >= 0x3_00 && codePoint <= 0x3_6F) {
 			continue;

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ export default function stringWidth(string, options = {}) {
 		}
 
 		// Ignore zero-width characters
-		if (codePoint === 0x200B) {
+		if (codePoint === 0x200_B) {
 			continue;
 		}
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ export default function stringWidth(string, options = {}) {
 		}
 
 		// Ignore zero-width characters
-		if (codePoint === 0x200_B) {
+		if (codePoint === 0x20_0B) {
 			continue;
 		}
 

--- a/test.js
+++ b/test.js
@@ -45,3 +45,9 @@ test('handles ZWJ characters', t => {
 	t.is(stringWidth('👩‍👩‍👦‍👦'), 2);
 	t.is(stringWidth('👨‍❤️‍💋‍👨'), 2);
 });
+
+test('handles zero-width characters', t => {
+	t.is(stringWidth('\u200B'), 0);
+	t.is(stringWidth('x\u200Bx'), 2);
+});
+


### PR DESCRIPTION
I submitted a pull request on sindresorhus/string-length#20 and was referred to this package which matches better with my changes. Zero-width characters are still treated as 1 character here, despite having no width.