### PR TITLE
Replace dependency emoji-regex with emoji-regex-xs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import stripAnsi from 'strip-ansi';
 import {eastAsianWidth} from 'get-east-asian-width';
-import emojiRegex from 'emoji-regex';
+import emojiRegex from 'emoji-regex-xs';
 
 const segmenter = new Intl.Segmenter();
 
@@ -38,7 +38,6 @@ export default function stringWidth(string, options = {}) {
 			continue;
 		}
 
-		// TODO: Use `/\p{RGI_Emoji}/v` when targeting Node.js 20.
 		if (emojiRegex().test(character)) {
 			width += 2;
 			continue;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"east-asian-width"
 	],
 	"dependencies": {
-		"emoji-regex": "^10.3.0",
+		"emoji-regex-xs": "^1.0.0",
 		"get-east-asian-width": "^1.0.0",
 		"strip-ansi": "^7.1.0"
 	},


### PR DESCRIPTION
`emoji-regex` is great but uses a large (~13 KB uncompressed) regex that lists thousands of code points. `emoji-regex-xs` is a drop-in replacement that shares its API and its 3000+ tests, but reduces the file size by 97% to ~0.3 KB. The significant difference is that it relies on flag `u` (from Node.js 10+ and 2016-era browsers) to accomplish this.

I've also removed a TODO about replacing the regex with `\p{RGI_Emoji}` since it is not a good replacement (see details in the `emoji-regex-xs` [readme](https://github.com/slevithan/emoji-regex-xs#more-details-about-emoji-unicode-properties-and-regexes)).