### PR TITLE
Replacing `strip-ansi` with `stripVTControlCharacters()` from `node:util`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
     steps:

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import {eastAsianWidth} from 'get-east-asian-width';
 import emojiRegex from 'emoji-regex';
 
@@ -17,7 +17,7 @@ export default function stringWidth(string, options = {}) {
 	} = options;
 
 	if (!countAnsiEscapeCodes) {
-		string = stripAnsi(string);
+		string = stripVTControlCharacters(string);
 	}
 
 	if (string.length === 0) {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
 	],
 	"dependencies": {
 		"emoji-regex": "^10.3.0",
-		"get-east-asian-width": "^1.0.0",
-		"strip-ansi": "^7.1.0"
+		"get-east-asian-width": "^1.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",


### PR DESCRIPTION
Reducing dependencies, similar to https://github.com/eslint/eslint/pull/18982 .

The method exists since v16.11
https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr

`string-width` min Node version is 18.