### PR TITLE
chore: remove strip-ansi dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import {eastAsianWidth} from 'get-east-asian-width';
 
 /**
@@ -78,9 +78,9 @@ export default function stringWidth(input, options = {}) {
 
 	let string = input;
 
-	// Avoid calling stripAnsi when there are no ANSI escape sequences (ESC = 0x1B, CSI = 0x9B)
+	// Avoid calling stripVTControlCharacters when there are no ANSI escape sequences (ESC = 0x1B, CSI = 0x9B)
 	if (!countAnsiEscapeCodes && (string.includes('\u001B') || string.includes('\u009B'))) {
-		string = stripAnsi(string);
+		string = stripVTControlCharacters(string);
 	}
 
 	if (string.length === 0) {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
 		"east-asian-width"
 	],
 	"dependencies": {
-		"get-east-asian-width": "^1.5.0",
-		"strip-ansi": "^7.1.2"
+		"get-east-asian-width": "^1.5.0"
 	},
 	"devDependencies": {
 		"ava": "^6.4.1",


### PR DESCRIPTION
strip-ansi has below note on its npm page. So this PR removes strip-ansi dependency to use node:util.

> [!NOTE] Node.js has this built-in now with [stripVTControlCharacters](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr). The benefit of this package is consistent behavior across Node.js versions and faster improvements. The Node.js version is actually based on this package.