### PR TITLE
Use `stripVTControlCharacters`, require Node.js 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 24
           - 22
-          - 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import {stripVTControlCharacters} from 'node:util';
 import {eastAsianWidth} from 'get-east-asian-width';
 
 /**
@@ -155,9 +155,9 @@ export default function stringWidth(input, options = {}) {
 
 	let string = input;
 
-	// Avoid calling stripAnsi when there are no ANSI escape sequences (ESC = 0x1B, CSI = 0x9B)
+	// Avoid calling stripVTControlCharacters when there are no ANSI escape sequences (ESC = 0x1B, CSI = 0x9B)
 	if (!countAnsiEscapeCodes && (string.includes('\u001B') || string.includes('\u009B'))) {
-		string = stripAnsi(string);
+		string = stripVTControlCharacters(string);
 	}
 
 	if (string.length === 0) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -54,8 +54,7 @@
 		"east-asian-width"
 	],
 	"dependencies": {
-		"get-east-asian-width": "^1.5.0",
-		"strip-ansi": "^7.1.2"
+		"get-east-asian-width": "^1.5.0"
 	},
 	"devDependencies": {
 		"ava": "^6.4.1",

--- a/test.js
+++ b/test.js
@@ -329,6 +329,6 @@ test('ambiguous in text (wide)', macro, '±×÷', 6, {ambiguousIsNarrow: false})
 test('ambiguous mixed with CJK', macro, '±你', 3);
 test('ambiguous mixed with CJK (wide)', macro, '±你', 4, {ambiguousIsNarrow: false});
 
-// `stripAnsi` guard: non-ANSI strings should not call `stripAnsi`
+// `stripVTControlCharacters` guard: non-ANSI strings should not trigger stripping
 test('non-ASCII without ANSI escapes', macro, '你好世界', 8);
 test('Latin1 without ANSI escapes', macro, 'résumé', 6);


### PR DESCRIPTION
Fixes #62

Replaces `strip-ansi` with the built-in `util.stripVTControlCharacters`, following up on the earlier attempts in #61 by @RobinTail and #73 by @dulmandakh, which were blocked because `stripVTControlCharacters` mishandled OSC 8 hyperlinks at the time. That was fixed in nodejs/node#54865 and shipped in Node.js 22.10.0, so engines is bumped to `>=22.10` rather than plain `>=22` to keep v22.0 through v22.9 from silently getting the old behavior. Node.js 20 is dropped from the CI matrix to match.

I checked the output of both functions against CSI sequences and OSC 8 hyperlinks (BEL and ST terminated) and they match exactly, and the existing hyperlink test in test.js covers the regression case. All 224 tests pass. Happy to adjust the engines range or split out the CI matrix change if you'd prefer to handle those separately.
